### PR TITLE
Fix random avatar

### DIFF
--- a/client/src/components/ChooseAvatar.js
+++ b/client/src/components/ChooseAvatar.js
@@ -5,10 +5,10 @@ import { ArrowLeftIcon, ArrowRightIcon } from "@modulz/radix-icons";
 
 import variables from "../styles/base/_variables.module.scss";
 
-const NUMBER_OF_EYES = Number(variables.maxChoiceEyes);
-const NUMBER_OF_HANDS = Number(variables.maxChoiceHands);
-const NUMBER_OF_HATS = Number(variables.maxChoiceHats);
-const NUMBER_OF_MOUTHES = Number(variables.maxChoiceMouthes);
+const NUMBER_OF_EYES = Number(variables.numberChoicesEyes);
+const NUMBER_OF_HANDS = Number(variables.numberChoicesHands);
+const NUMBER_OF_HATS = Number(variables.numberChoicesHats);
+const NUMBER_OF_MOUTHES = Number(variables.numberChoicesMouthes);
 
 const Select = (props) => {
   return (

--- a/client/src/components/ChooseAvatar.js
+++ b/client/src/components/ChooseAvatar.js
@@ -81,10 +81,10 @@ class ChooseAvatar extends Component {
 
   randomAvatar = () => {
     this.setState({ avatarChooserState: "not-saved" });
-    this.props.handleInputEyes(Math.round(Math.random() * NUMBER_OF_EYES));
-    this.props.handleInputHands(Math.round(Math.random() * NUMBER_OF_HANDS));
-    this.props.handleInputHat(Math.round(Math.random() * NUMBER_OF_HATS));
-    this.props.handleInputMouth(Math.round(Math.random() * NUMBER_OF_MOUTHES));
+    this.props.handleInputEyes(Math.floor(Math.random() * NUMBER_OF_EYES));
+    this.props.handleInputHands(Math.floor(Math.random() * NUMBER_OF_HANDS));
+    this.props.handleInputHat(Math.floor(Math.random() * NUMBER_OF_HATS));
+    this.props.handleInputMouth(Math.floor(Math.random() * NUMBER_OF_MOUTHES));
     this.props.handleInputColorBody(randomHexColor());
     this.props.handleInputColorBG(randomHexColor());
   };

--- a/client/src/styles/base/_variables.module.scss
+++ b/client/src/styles/base/_variables.module.scss
@@ -34,15 +34,15 @@ $color-red-error: #e23737;
 
 /* ---------- Avatar ---------- */
 /** These should match the number of possibilities in images/avatar/files.png */
-$max-choice-eyes: 5;
-$max-choice-hands: 5;
-$max-choice-hats: 5;
-$max-choice-mouthes: 5;
+$number-choices-eyes: 5;
+$number-choices-hands: 5;
+$number-choices-hats: 5;
+$number-choices-mouthes: 5;
 
 /* ---------- Make variables accessible from JS files ---------- */
 :export {
-  maxChoiceEyes: $max-choice-eyes;
-  maxChoiceHands: $max-choice-hands;
-  maxChoiceHats: $max-choice-hats;
-  maxChoiceMouthes: $max-choice-mouthes;
+  numberChoicesEyes: $number-choices-eyes;
+  numberChoicesHands: $number-choices-hands;
+  numberChoicesHats: $number-choices-hats;
+  numberChoicesMouthes: $number-choices-mouthes;
 }

--- a/client/src/styles/components/_Avatar.scss
+++ b/client/src/styles/components/_Avatar.scss
@@ -26,7 +26,12 @@
 
     @for $i
       from 1
-      through max($max-choice-eyes, $max-choice-hands, $max-choice-hats, $max-choice-mouthes)
+      through max(
+        $number-choices-eyes,
+        $number-choices-hands,
+        $number-choices-hats,
+        $number-choices-mouthes
+      )
     {
       img[data-choice="#{$i}"] {
         --offset: #{$i};


### PR DESCRIPTION
## Changes

<!--
 List all the changes made to the code. Add unticked items if some work has to be done
 Remove non applicable items
-->

- [x] Using `Math.round` in the random generation causes the generated value to be sometimes equal to the max (non reachable) value. Replacing by `Math.floor` resolves the issue: it's now always `0 ≤ result < number-of-choices`
- [x] Updated variables names to be clearer
