### PR TITLE
Use defaultProps for <Avatar>

### DIFF
--- a/client/src/components/Avatar.js
+++ b/client/src/components/Avatar.js
@@ -8,16 +8,7 @@ import ImageHands from "../images/avatar/hands.png";
 import ImageHats from "../images/avatar/hats.png";
 import ImageMouthes from "../images/avatar/mouthes.png";
 
-const Avatar = function ({
-  size,
-  eyes = 0,
-  hands = 0,
-  hat = 0,
-  mouth = 0,
-  colorBG = "#d3d3d3",
-  colorBody = "#0c04fc",
-  reversed = false,
-}) {
+const Avatar = function ({ size, eyes, hands, hat, mouth, colorBG, colorBody, reversed }) {
   return (
     <div
       className="avatar"
@@ -39,6 +30,16 @@ const Avatar = function ({
       </div>
     </div>
   );
+};
+
+Avatar.defaultProps = {
+  eyes: 0,
+  hands: 0,
+  hat: 0,
+  mouth: 0,
+  colorBody: "#0c04fc", // blue
+  colorBG: "#D3D3D3", // lightgray
+  reversed: false,
 };
 
 Avatar.propTypes = {

--- a/client/src/components/system/TopBar.js
+++ b/client/src/components/system/TopBar.js
@@ -9,19 +9,6 @@ import Avatar from "../Avatar";
 import SpriteSheet from "../SpriteSheet";
 
 class UserBadge extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      eyes: 0,
-      hands: 0,
-      hat: 0,
-      mouth: 0,
-      colorBody: "#0c04fc", // blue
-      colorBG: "#D3D3D3", // lightgray
-    };
-  }
-
   componentDidMount() {
     // TODO? Use global state?
     axios
@@ -49,12 +36,12 @@ class UserBadge extends Component {
       <Link to="/profile" id={"userBadge"}>
         <Avatar
           size="32px"
-          eyes={this.state.eyes}
-          hands={this.state.hands}
-          hat={this.state.hat}
-          mouth={this.state.mouth}
-          colorBody={this.state.colorBody}
-          colorBG={this.state.colorBG}
+          eyes={this.state?.eyes}
+          hands={this.state?.hands}
+          hat={this.state?.hat}
+          mouth={this.state?.mouth}
+          colorBody={this.state?.colorBody}
+          colorBG={this.state?.colorBG}
         />
         <span>{this.props.pseudo}</span>
       </Link>

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -11,14 +11,7 @@ export default class Profile extends Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      choiceEyes: 0,
-      choiceHands: 0,
-      choiceHat: 0,
-      choiceMouth: 0,
-      choiceColorBody: "#0c04fc", // blue
-      choiceColorBG: "#D3D3D3", // lightgray
-    };
+    this.state = Avatar.defaultProps;
   }
 
   componentDidMount() {
@@ -52,12 +45,12 @@ export default class Profile extends Component {
       <main id="profile">
         <Avatar
           size="256px"
-          eyes={this.state.choiceEyes}
-          hands={this.state.choiceHands}
-          hat={this.state.choiceHat}
-          mouth={this.state.choiceMouth}
-          colorBody={this.state.choiceColorBody}
-          colorBG={this.state.choiceColorBG}
+          eyes={this.state?.choiceEyes}
+          hands={this.state?.choiceHands}
+          hat={this.state?.choiceHat}
+          mouth={this.state?.choiceMouth}
+          colorBody={this.state?.choiceColorBody}
+          colorBG={this.state?.choiceColorBG}
         />
 
         <Collapsible.Root>
@@ -67,12 +60,12 @@ export default class Profile extends Component {
           </Collapsible.Button>
           <Collapsible.Content>
             <ChooseAvatar
-              choiceEyes={this.state.choiceEyes}
-              choiceHands={this.state.choiceHands}
-              choiceHat={this.state.choiceHat}
-              choiceMouth={this.state.choiceMouth}
-              choiceColorBody={this.state.choiceColorBody}
-              choiceColorBG={this.state.choiceColorBG}
+              choiceEyes={this.state?.choiceEyes}
+              choiceHands={this.state?.choiceHands}
+              choiceHat={this.state?.choiceHat}
+              choiceMouth={this.state?.choiceMouth}
+              choiceColorBody={this.state?.choiceColorBody}
+              choiceColorBG={this.state?.choiceColorBG}
               handleInputEyes={(val) => this.setState({ choiceEyes: parseInt(val) })}
               handleInputHands={(val) => this.setState({ choiceHands: parseInt(val) })}
               handleInputHat={(val) => this.setState({ choiceHat: parseInt(val) })}


### PR DESCRIPTION
## Changes

- [x] Use defaultProps (which I learned about in [this article](https://blog.bitsrc.io/understanding-react-default-props-5c50401ed37d) for the Avatar component instead of setting up the sames defaults variables in multiple places.
- ~~Updated [API documentation](https://github.com/ValFraNath/guacamole-api-docs)~~
- ~~Updated [Wiki](https://github.com/ValFraNath/glowing-octo-guacamole/wiki)~~

<details>
<summary>Hint</summary>
Don't look at the name of the branch
</details>